### PR TITLE
Update navbar.rb

### DIFF
--- a/lib/ui_bibz/ui/core/navigations/navbar.rb
+++ b/lib/ui_bibz/ui/core/navigations/navbar.rb
@@ -163,7 +163,7 @@ module UiBibz::Ui::Core::Navigations
     end
 
     def navbar_toggle_button_html
-      content_tag :button, '☰', class: 'navbar-toggler hidden-sm-up', type: :button, data: { "bs-toggle": 'collapse', target: "##{id}" }
+      content_tag :button, '☰', class: 'navbar-toggler hidden-sm-up', type: :button, data: { "bs-toggle": 'collapse', "bs-target": "##{id}" }
     end
 
     def expand_size


### PR DESCRIPTION
Fix target attribute for collapse from bootstrap 4 "data-target" to bootstrap 5 "data-bs-target" to enable hamburger / collapse button to work again. See https://getbootstrap.com/docs/5.0/components/collapse/  and https://getbootstrap.com/docs/5.0/components/navbar/ examples referring to bs-target